### PR TITLE
Fix navbar using full height on WebKit browsers

### DIFF
--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -22,18 +22,15 @@
   .md-tabs__link--active, .md-tabs__link:focus {
     border-bottom: 1.5px solid #b5b6b3;
     color: var(--md-primary-fg-color);
-    height: -webkit-fill-available;
   }
   .md-tabs__item--active {
     border-bottom: 1.5px solid #b5b6b3;
     color: var(--md-primary-fg-color);
-    height: -webkit-fill-available;
   }
   
   .md-tabs__link:hover {
     border-bottom: 1.5px solid #3447679f;
     color: var(--md-primary-fg-color);
-    height: -webkit-fill-available;
   }
   .md-nav__link[data-md-state=blur]:not(.md-nav__link--active) {
     color: inherit;


### PR DESCRIPTION
## Changes
**Fixes**:
- Removes the `height: -webkit-fill-available` property from the tab styles

Same issue as https://github.com/vatpac-technology/sops/pull/488 Tested using Safari. 

<img width="1808" height="1163" alt="Screenshot 2025-08-18 at 10 17 41 pm" src="https://github.com/user-attachments/assets/7f3d62a4-6a86-40a0-b056-c46ca8b0b8f8" />
